### PR TITLE
Add a way to override the servers where groups have to be searched

### DIFF
--- a/src/main/java/org/sonar/plugins/ldap/LdapGroupsProvider.java
+++ b/src/main/java/org/sonar/plugins/ldap/LdapGroupsProvider.java
@@ -70,10 +70,20 @@ public class LdapGroupsProvider extends ExternalGroupsProvider {
 
       if (searchResult != null) {
         try {
-          NamingEnumeration<SearchResult> result = groupMappings
-            .get(serverKey)
-            .createSearch(contextFactories.get(serverKey), searchResult).find();
-          groups.addAll(mapGroups(serverKey, result));
+          String[] serverKeysForGroup = groupMappings
+              .get(serverKey)
+              .getGroupRequestServersOverride();
+          if (serverKeysForGroup == null) {
+            serverKeysForGroup = new String[] { serverKey };
+          }
+          for(String serverKeyForGroup : serverKeysForGroup)
+          {
+            NamingEnumeration<SearchResult> result = groupMappings
+                .get(serverKeyForGroup)
+                .createSearch(contextFactories.get(serverKeyForGroup), searchResult)
+                .find();
+              groups.addAll(mapGroups(serverKey, result));
+          }
           // if no exceptions occur, we found the user and his groups and mapped his details.
           break;
         } catch (NamingException e) {

--- a/src/main/java/org/sonar/plugins/ldap/LdapSettingsManager.java
+++ b/src/main/java/org/sonar/plugins/ldap/LdapSettingsManager.java
@@ -105,7 +105,7 @@ public class LdapSettingsManager implements ServerExtension {
       String[] serverKeys = settings.getStringArray(LDAP_SERVERS_PROPERTY);
       if (serverKeys.length > 0) {
         for (String serverKey : serverKeys) {
-          LdapGroupMapping groupMapping = new LdapGroupMapping(settings, LDAP_PROPERTY_PREFIX + "." + serverKey);
+          LdapGroupMapping groupMapping = new LdapGroupMapping(settings, LDAP_PROPERTY_PREFIX, serverKey, serverKeys);
           if (StringUtils.isNotBlank(groupMapping.getBaseDn())) {
             LOG.info("Group mapping for server {}: {}", serverKey, groupMapping);
             groupMappings.put(serverKey, groupMapping);
@@ -115,7 +115,7 @@ public class LdapSettingsManager implements ServerExtension {
         }
       } else {
         // Backward compatibility with single server configuration
-        LdapGroupMapping groupMapping = new LdapGroupMapping(settings, LDAP_PROPERTY_PREFIX);
+        LdapGroupMapping groupMapping = new LdapGroupMapping(settings, LDAP_PROPERTY_PREFIX, null, null);
         if (StringUtils.isNotBlank(groupMapping.getBaseDn())) {
           LOG.info("Group mapping: {}", groupMapping);
           groupMappings.put(DEFAULT_LDAP_SERVER_KEY, groupMapping);

--- a/src/test/java/org/sonar/plugins/ldap/LdapGroupMappingTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/LdapGroupMappingTest.java
@@ -28,7 +28,7 @@ public class LdapGroupMappingTest {
 
   @Test
   public void defaults() {
-    LdapGroupMapping groupMapping = new LdapGroupMapping(new Settings(), "ldap");
+    LdapGroupMapping groupMapping = new LdapGroupMapping(new Settings(), "ldap", null, null);
 
     assertThat(groupMapping.getBaseDn()).isNull();
     assertThat(groupMapping.getIdAttribute()).isEqualTo("cn");
@@ -47,7 +47,7 @@ public class LdapGroupMappingTest {
     Settings settings = new Settings()
         .setProperty("ldap.group.objectClass", "group")
         .setProperty("ldap.group.memberAttribute", "member");
-    LdapGroupMapping groupMapping = new LdapGroupMapping(settings, "ldap");
+    LdapGroupMapping groupMapping = new LdapGroupMapping(settings, "ldap", null, null);
 
     assertThat(groupMapping.getRequest()).isEqualTo("(&(objectClass=group)(member={0}))");
   }
@@ -56,7 +56,7 @@ public class LdapGroupMappingTest {
   public void custom_request() {
     Settings settings = new Settings()
         .setProperty("ldap.group.request", "(&(|(objectClass=posixGroup)(objectClass=groupOfUniqueNames))(|(memberUid={uid})(uniqueMember={dn})))");
-    LdapGroupMapping groupMapping = new LdapGroupMapping(settings, "ldap");
+    LdapGroupMapping groupMapping = new LdapGroupMapping(settings, "ldap", null, null);
 
     assertThat(groupMapping.getRequest()).isEqualTo("(&(|(objectClass=posixGroup)(objectClass=groupOfUniqueNames))(|(memberUid={0})(uniqueMember={1})))");
     assertThat(groupMapping.getRequiredUserAttributes()).isEqualTo(new String[] {"uid", "dn"});

--- a/src/test/java/org/sonar/plugins/ldap/LdapGroupsProviderTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/LdapGroupsProviderTest.java
@@ -52,7 +52,7 @@ public class LdapGroupsProviderTest {
     Collection<String> groups;
 
     groups = groupsProvider.doGetGroups("tester");
-    assertThat(groups).containsOnly("sonar-users");
+    assertThat(groups).containsOnly("sonar-users", "example-cross-users");
 
     groups = groupsProvider.doGetGroups("godin");
     assertThat(groups).containsOnly("sonar-users", "sonar-developers");
@@ -71,7 +71,7 @@ public class LdapGroupsProviderTest {
     Collection<String> groups;
 
     groups = groupsProvider.doGetGroups("tester");
-    assertThat(groups).containsOnly("sonar-users");
+    assertThat(groups).containsOnly("sonar-users", "example-cross-users");
 
     groups = groupsProvider.doGetGroups("godin");
     assertThat(groups).containsOnly("sonar-users", "sonar-developers");
@@ -80,7 +80,7 @@ public class LdapGroupsProviderTest {
     assertThat(groups).isEmpty();
 
     groups = groupsProvider.doGetGroups("testerInfo");
-    assertThat(groups).containsOnly("sonar-users");
+    assertThat(groups).containsOnly("sonar-users", "infosupport-cross-users");
 
     groups = groupsProvider.doGetGroups("robby");
     assertThat(groups).containsOnly("sonar-users", "sonar-developers");
@@ -145,5 +145,53 @@ public class LdapGroupsProviderTest {
     groups = groupsProvider.doGetGroups("robby");
     assertThat(groups).containsOnly("sonar-users", "sonar-developers", "linux-users");
   }
+  
+  @Test
+  public void multipleLdapWithExternalGroupsDefaultBehavior() {
+    Settings settings = LdapSettingsFactory.generateSimpleAnonymousAccessSettings(exampleServer, infosupportServer);
+    LdapSettingsManager settingsManager = new LdapSettingsManager(settings, new LdapAutodiscovery());
+    LdapGroupsProvider groupsProvider = new LdapGroupsProvider(settingsManager.getContextFactories(), settingsManager.getUserMappings(), settingsManager.getGroupMappings());
 
+    Collection<String> groups;
+
+    groups = groupsProvider.doGetGroups("tester");
+    assertThat(groups).containsOnly("sonar-users", "example-cross-users");
+
+    groups = groupsProvider.doGetGroups("testerinfo");
+    assertThat(groups).containsOnly("sonar-users", "infosupport-cross-users");
+  }
+  
+  @Test
+  public void multipleLdapWithExternalGroupsSpecificServer() {
+    Settings settings = LdapSettingsFactory.generateSimpleAnonymousAccessSettings(exampleServer, infosupportServer);
+    settings.setProperty("ldap.example.group.searchServers", "infosupport");
+    LdapSettingsManager settingsManager = new LdapSettingsManager(settings, new LdapAutodiscovery());
+    LdapGroupsProvider groupsProvider = new LdapGroupsProvider(settingsManager.getContextFactories(), settingsManager.getUserMappings(), settingsManager.getGroupMappings());
+
+    Collection<String> groups;
+
+    groups = groupsProvider.doGetGroups("tester");
+    assertThat(groups).containsOnly("infosupport-cross-users");
+
+    groups = groupsProvider.doGetGroups("testerinfo");
+    assertThat(groups).containsOnly("sonar-users", "infosupport-cross-users");
+  }
+  
+  @Test
+  public void multipleLdapWithExternalGroupsSpecificListOfServer() {
+    Settings settings = LdapSettingsFactory.generateSimpleAnonymousAccessSettings(exampleServer, infosupportServer);
+    settings.setProperty("ldap.example.group.searchServers", "example,infosupport");
+    LdapSettingsManager settingsManager = new LdapSettingsManager(settings, new LdapAutodiscovery());
+    LdapGroupsProvider groupsProvider = new LdapGroupsProvider(settingsManager.getContextFactories(), settingsManager.getUserMappings(), settingsManager.getGroupMappings());
+
+    Collection<String> groups;
+
+    groups = groupsProvider.doGetGroups("tester");
+    assertThat(groups).containsOnly("sonar-users", "infosupport-cross-users", "example-cross-users");
+
+    groups = groupsProvider.doGetGroups("testerinfo");
+    assertThat(groups).containsOnly("sonar-users", "infosupport-cross-users");
+  }
+  
+  
 }

--- a/src/test/resources/users.example.org.ldif
+++ b/src/test/resources/users.example.org.ldif
@@ -96,3 +96,10 @@ objectclass: top
 cn: linux-users
 gidNumber: 10000
 memberUid: godin
+
+# example-cross-users
+dn: cn=example-cross-users,ou=groups,dc=example,dc=org
+objectclass: groupOfUniqueNames
+cn: example-cross-users
+uniqueMember: cn=Tester Testerovich,ou=users,dc=example,dc=org
+uniqueMember: cn=Tester Testerovich,ou=users,dc=infosupport,dc=com

--- a/src/test/resources/users.infosupport.com.ldif
+++ b/src/test/resources/users.infosupport.com.ldif
@@ -96,3 +96,10 @@ objectclass: top
 cn: linux-users
 gidNumber: 10000
 memberUid: robby
+
+# infosupport-cross-users
+dn: cn=infosupport-cross-users,ou=groups,dc=infosupport,dc=com
+objectclass: groupOfUniqueNames
+cn: infosupport-cross-users
+uniqueMember: cn=Tester Testerovich,ou=users,dc=example,dc=org
+uniqueMember: cn=Tester Testerovich,ou=users,dc=infosupport,dc=com


### PR DESCRIPTION
Hi,

In my organisation, we have users on several domains, but we use groups from only one of these domains to set access rights.
In the current implementation of the plugin, only groups in the user's domain are retrieved.

Please find my proposal to help configure how groups have to be retrieved.
The basic idea is to not touch the current behavior, but to add a way for each ldap server to specify from where groups have to be retrieved for users of this server.

I'm not familiar with SonarQube coding standard, so do not hesitate to tell me if I need to correct/change something.

Regards,
