### PR TITLE
Reducing the number of settings required in auto-discovery

### DIFF
--- a/src/main/java/org/sonar/plugins/ldap/LdapExtensions.java
+++ b/src/main/java/org/sonar/plugins/ldap/LdapExtensions.java
@@ -86,6 +86,6 @@ public class LdapExtensions extends ExtensionProvider implements ServerExtension
   }
 
   private List<Class<?>> getLdapExtensions() {
-    return Arrays.asList(LdapRealm.class, LdapSettingsManager.class, LdapAutodiscovery.class);
+    return Arrays.asList(LdapRealm.class, LdapSettingsManager.class, LdapAutodiscovery.class, LdapSettings.class);
   }
 }

--- a/src/main/java/org/sonar/plugins/ldap/LdapRealm.java
+++ b/src/main/java/org/sonar/plugins/ldap/LdapRealm.java
@@ -20,9 +20,9 @@
 package org.sonar.plugins.ldap;
 
 import java.util.Map;
+import org.sonar.api.security.Authenticator;
 import org.sonar.api.security.ExternalGroupsProvider;
 import org.sonar.api.security.ExternalUsersProvider;
-import org.sonar.api.security.LoginPasswordAuthenticator;
 import org.sonar.api.security.SecurityRealm;
 
 /**
@@ -66,7 +66,7 @@ public class LdapRealm extends SecurityRealm {
   }
 
   @Override
-  public LoginPasswordAuthenticator getLoginPasswordAuthenticator() {
+  public Authenticator doGetAuthenticator() {
     return authenticator;
   }
 

--- a/src/main/java/org/sonar/plugins/ldap/LdapSettings.java
+++ b/src/main/java/org/sonar/plugins/ldap/LdapSettings.java
@@ -1,0 +1,203 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.config.Settings;
+import org.sonar.api.server.ServerSide;
+
+@ServerSide
+public class LdapSettings {
+  public static final String LDAP_PROPERTY_PREFIX = "ldap";
+  @VisibleForTesting
+  static final String AUTHENTICATION_METHOD_PROPERTY_SUFFIX = ".authentication";
+  @VisibleForTesting
+  static final String CONTEXT_FACTORY_CLASS_PROPERTY_SUFFIX = ".contextFactoryClass";
+  @VisibleForTesting
+  static final String LDAP_REALM_PROPERTY_SUFFIX = ".realm";
+  @VisibleForTesting
+  static final String LDAP_URL_PROPERTY_SUFFIX = ".url";
+  @VisibleForTesting
+  static final String LDAP_BIND_DN_PROPERTY_SUFFIX = ".bindDn";
+  @VisibleForTesting
+  static final String LDAP_BIND_PWD_PROPERTY_SUFFIX = ".bindPassword";
+
+  @VisibleForTesting
+  static final String DEFAULT_AUTHENTICATION = "simple";
+  @VisibleForTesting
+  static final String DEFAULT_LDAP_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
+  @VisibleForTesting
+  static final String LDAP_SERVERS_PROPERTY = LDAP_PROPERTY_PREFIX + ".servers";
+
+  @VisibleForTesting
+  static class User {
+    public static final String BASE_DN_PROPERTY_SUFFIX = ".user.baseDn";
+    public static final String REQUEST_PROPERTY_SUFFIX = ".user.request";
+
+    public static final String REAL_NAME_ATTRIBUTE_PROPERTY_SUFFIX = ".user.realNameAttribute";
+    public static final String EMAIL_ATTRIBUTE_PROPERTY_SUFFIX = ".user.emailAttribute";
+    public static final String OBJECT_CLASS_PROPERTY_SUFFIX = ".user.objectClass";
+    public static final String LOGIN_ATTRIBUTE_PROPERTY_SUFFIX = ".user.loginAttribute";
+
+    public static final String DEFAULT_REQUEST = "(|(&(objectClass=inetOrgPerson)(uid={login}))(&(objectClass=user)(sAMAccountName={login})))";
+    public static final String DEFAULT_REAL_NAME_ATTRIBUTE = "cn";
+    public static final String DEFAULT_EMAIL_ATTRIBUTE = "mail";
+    public static final String DEFAULT_OBJECT_CLASS = "inetOrgPerson";
+    public static final String DEFAULT_LOGIN_ATTRIBUTE = "uid";
+
+    private User() {
+    }
+  }
+
+  @VisibleForTesting
+  static class Group {
+    public static final String BASE_DN_PROPERTY_SUFFIX = ".group.baseDn";
+    public static final String REQUEST_PROPERTY_SUFFIX = ".group.request";
+    public static final String OBJECT_CLASS_PROPERTY_SUFFIX = ".group.objectClass";
+    public static final String MEMBER_ATTRIBUTE_PROPERTY_SUFFIX = ".group.memberAttribute";
+    public static final String ID_ATTRIBUTE_PROPERTY_SUFFIX = ".group.idAttribute";
+
+    public static final String DEFAULT_REQUEST = "(|(&(objectClass=groupOfUniqueNames)(uniqueMember={dn}))(&(objectClass=group)(member={dn})))";
+    public static final String DEFAULT_OBJECT_CLASS = "groupOfUniqueNames";
+    public static final String DEFAULT_MEMBER_ATTRIBUTE = "uniqueMember";
+    public static final String DEFAULT_ID_ATTRIBUTE = "cn";
+
+    private Group() {
+    }
+  }
+
+  private final Settings settings;
+
+  public LdapSettings(Settings settings) {
+    this.settings = settings;
+  }
+
+  public String[] getLdapServerKeys() {
+    return settings.getStringArray(LDAP_SERVERS_PROPERTY);
+  }
+
+  public String getLdapAuthenticationOrDefault(String settingsPrefix) {
+    return StringUtils.defaultString(settings.getString(settingsPrefix + AUTHENTICATION_METHOD_PROPERTY_SUFFIX),
+      DEFAULT_AUTHENTICATION);
+  }
+
+  public String getLdapContextFactoryOrDefault(String settingsPrefix) {
+    return StringUtils.defaultString(settings.getString(settingsPrefix + CONTEXT_FACTORY_CLASS_PROPERTY_SUFFIX),
+      DEFAULT_LDAP_CONTEXT_FACTORY);
+  }
+
+  public String getLdapRealm(String settingsPrefix) {
+    return settings.getString(settingsPrefix + LDAP_REALM_PROPERTY_SUFFIX);
+  }
+
+  public String getLdapUrl(String settingsPrefix) {
+    return settings.getString(settingsPrefix + LDAP_URL_PROPERTY_SUFFIX);
+  }
+
+  public String getLdapUrlKey(String settingsPrefix) {
+    return settingsPrefix + LDAP_URL_PROPERTY_SUFFIX;
+  }
+
+  public String getBindUserNameDn(String settingsPrefix) {
+    return settings.getString(settingsPrefix + LDAP_BIND_DN_PROPERTY_SUFFIX);
+  }
+
+  public String getBindPassword(String settingsPrefix) {
+    return settings.getString(settingsPrefix + LDAP_BIND_PWD_PROPERTY_SUFFIX);
+  }
+
+  public String getUserBaseDn(String settingsPrefix) {
+    return settings.getString(settingsPrefix + User.BASE_DN_PROPERTY_SUFFIX);
+  }
+
+  public String getUserObjectClassAttributeOrDefault(String settingsPrefix) {
+    return StringUtils.defaultString(getUserObjectClassAttribute(settingsPrefix),
+      User.DEFAULT_OBJECT_CLASS);
+  }
+
+  public String getUserObjectClassAttribute(String settingsPrefix) {
+    return settings.getString(settingsPrefix + User.OBJECT_CLASS_PROPERTY_SUFFIX);
+  }
+
+  public String getUserLoginAttributeOrDefault(String settingsPrefix) {
+    return StringUtils.defaultString(getUserLoginAttribute(settingsPrefix), User.DEFAULT_LOGIN_ATTRIBUTE);
+  }
+
+  public String getUserLoginAttribute(String settingsPrefix) {
+    return settings.getString(settingsPrefix + User.LOGIN_ATTRIBUTE_PROPERTY_SUFFIX);
+  }
+
+  public String getUserRealNameAttributeOrDefault(String settingsPrefix) {
+    return StringUtils.defaultString(settings.getString(settingsPrefix + User.REAL_NAME_ATTRIBUTE_PROPERTY_SUFFIX),
+      User.DEFAULT_REAL_NAME_ATTRIBUTE);
+  }
+
+  public String getUserEmailAttributeOrDefault(String settingsPrefix) {
+    return StringUtils.defaultString(settings.getString(settingsPrefix + User.EMAIL_ATTRIBUTE_PROPERTY_SUFFIX),
+      User.DEFAULT_EMAIL_ATTRIBUTE);
+  }
+
+  public String getUserRequestOrDefault(String settingsPrefix) {
+    return StringUtils.defaultString(settings.getString(settingsPrefix + User.REQUEST_PROPERTY_SUFFIX),
+      User.DEFAULT_REQUEST);
+  }
+
+  public String getUserGroupRequestOrDefault(String settingsPrefix) {
+    return StringUtils.defaultString(settings.getString(settingsPrefix + Group.REQUEST_PROPERTY_SUFFIX),
+      Group.DEFAULT_REQUEST);
+  }
+
+  public String getUserGroupBaseDn(String settingsPrefix) {
+    return settings.getString(settingsPrefix + Group.BASE_DN_PROPERTY_SUFFIX);
+  }
+
+  public String getUserGroupObjectClass(String settingsPrefix) {
+    return settings.getString(settingsPrefix + Group.OBJECT_CLASS_PROPERTY_SUFFIX);
+  }
+
+  public String getUserGroupObjectClassOrDefault(String settingsPrefix) {
+    return StringUtils.defaultString(getUserGroupObjectClass(settingsPrefix),
+      Group.DEFAULT_OBJECT_CLASS);
+  }
+
+  public String getUserGroupMemberAttribute(String settingsPrefix) {
+    return settings.getString(settingsPrefix + Group.MEMBER_ATTRIBUTE_PROPERTY_SUFFIX);
+  }
+
+  public String getUserGroupMemberAttributeOrDefault(String settingsPrefix) {
+    return StringUtils.defaultString(getUserGroupMemberAttribute(settingsPrefix),
+      Group.DEFAULT_MEMBER_ATTRIBUTE);
+  }
+
+  public String getUserGroupIdAttributeOrDefault(String settingsPrefix) {
+    return StringUtils.defaultString(settings.getString(settingsPrefix + Group.ID_ATTRIBUTE_PROPERTY_SUFFIX),
+      Group.DEFAULT_ID_ATTRIBUTE);
+  }
+
+  public boolean hasKey(String key) {
+    return settings.hasKey(key);
+  }
+
+  public boolean isAutoDiscoveryEnabled() {
+    return this.getLdapUrl(LDAP_PROPERTY_PREFIX) == null &&
+      this.getLdapRealm(LDAP_PROPERTY_PREFIX) != null;
+  }
+}

--- a/src/main/java/org/sonar/plugins/ldap/windows/AdConnectionHelper.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/AdConnectionHelper.java
@@ -160,7 +160,7 @@ public class AdConnectionHelper {
         return userGroups;
       }
 
-      Collection<String> adUserGroups = getUserGroupsFromAd(connection, activeDirectoryBindString, domainName, userNameDn,
+      Collection<String> adUserGroups = getUserGroupsFromAd(connection, activeDirectoryBindString, userNameDn,
         requestedGroupIdAttribute);
       userGroups.addAll(adUserGroups);
 
@@ -256,7 +256,7 @@ public class AdConnectionHelper {
     return attributeValue;
   }
 
-  private Object getRootDseAttribute(IADs rootDse, String attributeName) {
+  private static Object getRootDseAttribute(IADs rootDse, String attributeName) {
     Object attributeValue = null;
     try {
       LOG.trace("Getting value of {} from {}", attributeName, ROOT_DSE);
@@ -310,7 +310,7 @@ public class AdConnectionHelper {
     return userAttributes.get(DISTINGUISHED_NAME_STR);
   }
 
-  private Collection<String> getUserGroupsFromAd(final _Connection connection, final String connectionUrl, String domainName,
+  private Collection<String> getUserGroupsFromAd(final _Connection connection, final String connectionUrl,
     final String userNameDn, final String requestedGroupIdAttribute) {
     Collection<String> adUserGroups = new ArrayList<>();
 
@@ -397,7 +397,7 @@ public class AdConnectionHelper {
    * User Details Command Text format <LDAP://domain/root>;(filter);requestedAttributes;scope
    * e.g.<LDAP://domain/DC=domain, dc=com>;(sAMAccountName=userName);cn,mail;SubTree
    */
-  private String getUserDetailsCommandText(final String bindString, final String userName,
+  private static String getUserDetailsCommandText(final String bindString, final String userName,
     final Collection<String> requestedDetails) {
     /* Filter on sAMAccountName attribute */
     String filter = String.format("(%s=%s)", SAMACCOUNTNAME_STR, userName);
@@ -410,7 +410,7 @@ public class AdConnectionHelper {
   /*
    * User Groups Command Text format <LDAP://domain/root>;(filter);requestedAttributes;scope
    */
-  private String getUserGroupsCommandText(final String bindString, final String userDn,
+  private static String getUserGroupsCommandText(final String bindString, final String userDn,
     final String requestedDetail) {
     /* Filter on user dn attribute */
     String filter = String.format("(&(objectClass=group)(member=%s))", userDn);

--- a/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelper.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelper.java
@@ -50,6 +50,7 @@ public class WindowsAuthenticationHelper {
   public static final String BASIC_AUTH_PRINCIPAL_KEY = "ldap.windows.Principal";
 
   private static final Logger LOG = Loggers.get(WindowsAuthenticationHelper.class);
+  private static final String REQUEST_IS_NULL_STRING = "request is null";
 
   private final AdConnectionHelper adConnectionHelper;
   private final IWindowsAuthProvider windowsAuthProvider;
@@ -70,7 +71,7 @@ public class WindowsAuthenticationHelper {
    * Checks if the request has valid {@link WindowsPrincipal}
    */
   public boolean isUserSsoAuthenticated(HttpServletRequest request) {
-    checkNotNull(request, "request is null");
+    checkNotNull(request, REQUEST_IS_NULL_STRING);
 
     return getWindowsPrincipal(request, WindowsAuthenticationHelper.SSO_PRINCIPAL_KEY) != null;
   }
@@ -79,7 +80,7 @@ public class WindowsAuthenticationHelper {
    * Returns {@link WindowsPrincipal} from given {@link HttpServletRequest}
    */
   public WindowsPrincipal getWindowsPrincipal(HttpServletRequest request, String windowsPrincipalKey) {
-    checkNotNull(request, "request is null");
+    checkNotNull(request, REQUEST_IS_NULL_STRING);
     checkNotNull(windowsPrincipalKey, "windowsPrincipalKey is null");
 
     WindowsPrincipal windowsPrincipal = null;
@@ -98,7 +99,7 @@ public class WindowsAuthenticationHelper {
    * Sets {@link WindowsPrincipal} in {@link HttpSession} of given {@link HttpServletRequest}
    */
   public void setWindowsPrincipalForBasicAuth(HttpServletRequest request, WindowsPrincipal windowsPrincipal) {
-    checkNotNull(request, "request is null");
+    checkNotNull(request, REQUEST_IS_NULL_STRING);
     checkNotNull(windowsPrincipal, "windowsPrincipal is null");
 
     HttpSession session = request.getSession();
@@ -111,7 +112,7 @@ public class WindowsAuthenticationHelper {
    * Removes basic auth principal key from{@link HttpSession} of given {@link HttpServletRequest}
    */
   public void removeWindowsPrincipalForBasicAuth(HttpServletRequest request) {
-    checkNotNull(request, "request is null");
+    checkNotNull(request, REQUEST_IS_NULL_STRING);
 
     HttpSession session = request.getSession();
     if (session != null) {
@@ -123,7 +124,7 @@ public class WindowsAuthenticationHelper {
    * Removes sso principal key from {@link HttpSession} of given {@link HttpServletRequest}
    */
   public void removeWindowsPrincipalForSso(HttpServletRequest request) {
-    checkNotNull(request, "request is null");
+    checkNotNull(request, REQUEST_IS_NULL_STRING);
 
     HttpSession session = request.getSession();
     if (session != null) {
@@ -166,7 +167,7 @@ public class WindowsAuthenticationHelper {
    */
   @CheckForNull
   public UserDetails getSsoUserDetails(HttpServletRequest request) {
-    checkNotNull(request, "request is null");
+    checkNotNull(request, REQUEST_IS_NULL_STRING);
 
     WindowsPrincipal windowsPrincipal = getWindowsPrincipal(request, WindowsAuthenticationHelper.SSO_PRINCIPAL_KEY);
     return windowsPrincipal != null ? getUserDetails(windowsPrincipal.getName()) : null;
@@ -235,7 +236,7 @@ public class WindowsAuthenticationHelper {
 
     Map<String, String> adUserDetails = getAdUserDetails(windowsAccount.getDomain(), windowsAccount.getName());
     if (!adUserDetails.isEmpty()) {
-      userDetails.setName(adUserDetails.get(settings.getLdapUserRealNameAttribute()));
+      userDetails.setName(adUserDetails.get(AdConnectionHelper.COMMON_NAME_ATTRIBUTE));
       userDetails.setEmail(adUserDetails.get(AdConnectionHelper.MAIL_ATTRIBUTE));
     } else {
       LOG.debug("Unable to get name and email for user: {}", windowsAccount.getFqn());
@@ -272,9 +273,9 @@ public class WindowsAuthenticationHelper {
     return windowsAccount;
   }
 
-  private Map<String, String> getAdUserDetails(String domainName, String name) {      
+  private Map<String, String> getAdUserDetails(String domainName, String name) {
     Collection<String> requestedDetails = new ArrayList<>();
-    requestedDetails.add(settings.getLdapUserRealNameAttribute());
+    requestedDetails.add(AdConnectionHelper.COMMON_NAME_ATTRIBUTE);
     requestedDetails.add(AdConnectionHelper.MAIL_ATTRIBUTE);
     return adConnectionHelper.getUserDetails(domainName, name, requestedDetails);
   }

--- a/src/main/java/org/sonar/plugins/ldap/windows/auth/WindowsAuthSettings.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/auth/WindowsAuthSettings.java
@@ -57,13 +57,7 @@ public class WindowsAuthSettings {
    * Setting to specify group-id attribute, which is used by plugin while returning user groups in compatibility mode
    */
   public static final String LDAP_GROUP_ID_ATTRIBUTE = "ldap.group.idAttribute";
-  
-  /**
-   * Settings to specify real name attribute for a user
-   */
-  public static final String LDAP_WINDOWS_USER_REAL_NAME_ATTRIBUTE = LDAP_WINDOWS + ".user.realNameAttribute"; 
 
-  public static final String DEFAULT_USER_REAL_NAME_ATTRIBUTE = "cn";
   public static final String DEFAULT_SONAR_LDAP_WINDOWS_AUTH = "true";
   public static final String DEFAULT_SONAR_WINDOWS_AUTH_SSO_PROTOCOLS = "NTLM";
   public static final boolean DEFAULT_WINDOWS_COMPATIBILITY_MODE = false;
@@ -123,13 +117,6 @@ public class WindowsAuthSettings {
    */
   public String getProtocols() {
     return StringUtils.defaultIfBlank(settings.getString(LDAP_WINDOWS_AUTH_SSO_PROTOCOLS), DEFAULT_SONAR_WINDOWS_AUTH_SSO_PROTOCOLS);
-  }
-  
-  /**
-   * Returns the specified value for the real name attribute. By default, it's value is "cn"
-   */
-  public String getLdapUserRealNameAttribute(){ 
-      return StringUtils.defaultIfBlank(settings.getString(LDAP_WINDOWS_USER_REAL_NAME_ATTRIBUTE), DEFAULT_USER_REAL_NAME_ATTRIBUTE ); 
   }
 
 }

--- a/src/test/java/org/sonar/plugins/ldap/LdapExtensionsTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/LdapExtensionsTest.java
@@ -107,7 +107,7 @@ public class LdapExtensionsTest {
   }
 
   private List<Class<?>> getExpectedLdapExtensions() {
-    return Arrays.asList(LdapRealm.class, LdapSettingsManager.class, LdapAutodiscovery.class);
+    return Arrays.asList(LdapRealm.class, LdapSettingsManager.class, LdapAutodiscovery.class, LdapSettings.class);
   }
 
   private List<Class<?>> getExpectedWindowsExtensions() {

--- a/src/test/java/org/sonar/plugins/ldap/LdapGroupMappingTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/LdapGroupMappingTest.java
@@ -28,26 +28,26 @@ public class LdapGroupMappingTest {
 
   @Test
   public void defaults() {
-    LdapGroupMapping groupMapping = new LdapGroupMapping(new Settings(), "ldap");
+    LdapGroupMapping groupMapping = new LdapGroupMapping(new LdapSettings(new Settings()), "ldap");
 
     assertThat(groupMapping.getBaseDn()).isNull();
     assertThat(groupMapping.getIdAttribute()).isEqualTo("cn");
-    assertThat(groupMapping.getRequest()).isEqualTo("(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))");
-    assertThat(groupMapping.getRequiredUserAttributes()).isEqualTo(new String[] {"dn"});
+    assertThat(groupMapping.getRequest()).isEqualTo("(|(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))(&(objectClass=group)(member={0})))");
+    assertThat(groupMapping.getRequiredUserAttributes()).isEqualTo(new String[] {"dn", "dn"});
 
     assertThat(groupMapping.toString()).isEqualTo("LdapGroupMapping{" +
       "baseDn=null," +
       " idAttribute=cn," +
-      " requiredUserAttributes=[dn]," +
-      " request=(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))}");
+      " requiredUserAttributes=[dn, dn]," +
+      " request=(|(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))(&(objectClass=group)(member={0})))}");
   }
 
   @Test
   public void backward_compatibility() {
     Settings settings = new Settings()
-        .setProperty("ldap.group.objectClass", "group")
-        .setProperty("ldap.group.memberAttribute", "member");
-    LdapGroupMapping groupMapping = new LdapGroupMapping(settings, "ldap");
+      .setProperty("ldap.group.objectClass", "group")
+      .setProperty("ldap.group.memberAttribute", "member");
+    LdapGroupMapping groupMapping = new LdapGroupMapping(new LdapSettings(settings), "ldap");
 
     assertThat(groupMapping.getRequest()).isEqualTo("(&(objectClass=group)(member={0}))");
   }
@@ -55,8 +55,8 @@ public class LdapGroupMappingTest {
   @Test
   public void custom_request() {
     Settings settings = new Settings()
-        .setProperty("ldap.group.request", "(&(|(objectClass=posixGroup)(objectClass=groupOfUniqueNames))(|(memberUid={uid})(uniqueMember={dn})))");
-    LdapGroupMapping groupMapping = new LdapGroupMapping(settings, "ldap");
+      .setProperty("ldap.group.request", "(&(|(objectClass=posixGroup)(objectClass=groupOfUniqueNames))(|(memberUid={uid})(uniqueMember={dn})))");
+    LdapGroupMapping groupMapping = new LdapGroupMapping(new LdapSettings(settings), "ldap");
 
     assertThat(groupMapping.getRequest()).isEqualTo("(&(|(objectClass=posixGroup)(objectClass=groupOfUniqueNames))(|(memberUid={0})(uniqueMember={1})))");
     assertThat(groupMapping.getRequiredUserAttributes()).isEqualTo(new String[] {"uid", "dn"});

--- a/src/test/java/org/sonar/plugins/ldap/LdapSearchTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/LdapSearchTest.java
@@ -28,6 +28,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.sonar.api.config.Settings;
 import org.sonar.plugins.ldap.server.LdapServer;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,7 +45,8 @@ public class LdapSearchTest {
 
   @BeforeClass
   public static void init() {
-    contextFactories = new LdapSettingsManager(LdapSettingsFactory.generateSimpleAnonymousAccessSettings(server, null), new LdapAutodiscovery()).getContextFactories();
+    Settings settings = LdapSettingsFactory.generateSimpleAnonymousAccessSettings(server, null);
+    contextFactories = new LdapSettingsManager(new LdapSettings(settings), new LdapAutodiscovery()).getContextFactories();
   }
 
   @Test

--- a/src/test/java/org/sonar/plugins/ldap/LdapSettingsFactory.java
+++ b/src/test/java/org/sonar/plugins/ldap/LdapSettingsFactory.java
@@ -39,22 +39,21 @@ public class LdapSettingsFactory {
       settings.setProperty("ldap.servers", "example,infosupport");
 
       settings.setProperty("ldap.example.url", exampleServer.getUrl())
-          .setProperty("ldap.example.user.baseDn", "ou=users,dc=example,dc=org")
-          .setProperty("ldap.example.group.baseDn", "ou=groups,dc=example,dc=org");
+        .setProperty("ldap.example.user.baseDn", "ou=users,dc=example,dc=org")
+        .setProperty("ldap.example.group.baseDn", "ou=groups,dc=example,dc=org");
       settings.setProperty("ldap.infosupport.url", infosupportServer.getUrl())
-          .setProperty("ldap.infosupport.user.baseDn", "ou=users,dc=infosupport,dc=com")
-          .setProperty("ldap.infosupport.group.baseDn", "ou=groups,dc=infosupport,dc=com");
-    }
-    else {
+        .setProperty("ldap.infosupport.user.baseDn", "ou=users,dc=infosupport,dc=com")
+        .setProperty("ldap.infosupport.group.baseDn", "ou=groups,dc=infosupport,dc=com");
+    } else {
       settings.setProperty("ldap.url", exampleServer.getUrl())
-          .setProperty("ldap.user.baseDn", "ou=users,dc=example,dc=org")
-          .setProperty("ldap.group.baseDn", "ou=groups,dc=example,dc=org");
+        .setProperty("ldap.user.baseDn", "ou=users,dc=example,dc=org")
+        .setProperty("ldap.group.baseDn", "ou=groups,dc=example,dc=org");
     }
     return settings;
   }
 
   /**
-   * Generate settings for 2 ldap servers that require authenticaten.
+   * Generate settings for 2 ldap servers that require authentication.
    *
    * @param exampleServer     The first ldap server.
    * @param infosupportServer The second ldap server.
@@ -67,28 +66,27 @@ public class LdapSettingsFactory {
       settings.setProperty("ldap.servers", "example,infosupport");
 
       settings.setProperty("ldap.example.url", exampleServer.getUrl())
-          .setProperty("ldap.example.bindDn", "bind")
-          .setProperty("ldap.example.bindPassword", "bindpassword")
-          .setProperty("ldap.example.authentication", LdapContextFactory.CRAM_MD5_METHOD)
-          .setProperty("ldap.example.realm", "example.org")
-          .setProperty("ldap.example.user.baseDn", "ou=users,dc=example,dc=org")
-          .setProperty("ldap.example.group.baseDn", "ou=groups,dc=example,dc=org");
+        .setProperty("ldap.example.bindDn", "bind")
+        .setProperty("ldap.example.bindPassword", "bindpassword")
+        .setProperty("ldap.example.authentication", LdapContextFactory.AUTH_METHOD_CRAM_MD5)
+        .setProperty("ldap.example.realm", "example.org")
+        .setProperty("ldap.example.user.baseDn", "ou=users,dc=example,dc=org")
+        .setProperty("ldap.example.group.baseDn", "ou=groups,dc=example,dc=org");
       settings.setProperty("ldap.infosupport.url", infosupportServer.getUrl())
-          .setProperty("ldap.infosupport.bindDn", "bind")
-          .setProperty("ldap.infosupport.bindPassword", "bindpassword")
-          .setProperty("ldap.infosupport.authentication", LdapContextFactory.CRAM_MD5_METHOD)
-          .setProperty("ldap.infosupport.realm", "infosupport.com")
-          .setProperty("ldap.infosupport.user.baseDn", "ou=users,dc=infosupport,dc=com")
-          .setProperty("ldap.infosupport.group.baseDn", "ou=groups,dc=infosupport,dc=com");
-    }
-    else {
+        .setProperty("ldap.infosupport.bindDn", "bind")
+        .setProperty("ldap.infosupport.bindPassword", "bindpassword")
+        .setProperty("ldap.infosupport.authentication", LdapContextFactory.AUTH_METHOD_CRAM_MD5)
+        .setProperty("ldap.infosupport.realm", "infosupport.com")
+        .setProperty("ldap.infosupport.user.baseDn", "ou=users,dc=infosupport,dc=com")
+        .setProperty("ldap.infosupport.group.baseDn", "ou=groups,dc=infosupport,dc=com");
+    } else {
       settings.setProperty("ldap.url", exampleServer.getUrl())
-          .setProperty("ldap.bindDn", "bind")
-          .setProperty("ldap.bindPassword", "bindpassword")
-          .setProperty("ldap.authentication", LdapContextFactory.CRAM_MD5_METHOD)
-          .setProperty("ldap.realm", "example.org")
-          .setProperty("ldap.user.baseDn", "ou=users,dc=example,dc=org")
-          .setProperty("ldap.group.baseDn", "ou=groups,dc=example,dc=org");
+        .setProperty("ldap.bindDn", "bind")
+        .setProperty("ldap.bindPassword", "bindpassword")
+        .setProperty("ldap.authentication", LdapContextFactory.AUTH_METHOD_CRAM_MD5)
+        .setProperty("ldap.realm", "example.org")
+        .setProperty("ldap.user.baseDn", "ou=users,dc=example,dc=org")
+        .setProperty("ldap.group.baseDn", "ou=groups,dc=example,dc=org");
     }
     return settings;
   }

--- a/src/test/java/org/sonar/plugins/ldap/LdapSettingsTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/LdapSettingsTest.java
@@ -1,0 +1,182 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * sonarqube@googlegroups.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap;
+
+import org.junit.Test;
+import org.sonar.api.config.Settings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LdapSettingsTest {
+  private static String TEST_LDAP_AUTHENTICATION_METHOD = "SomeAuthMethod";
+  private static String TEST_LDAP_CONTEXT_FACTORY = "SomeContextFactory";
+  private static String TEST_LDAP_URL = "Ldap url";
+  private static String TEST_SERVER_BIND_DN = "server bind dn";
+  private static String TEST_SERVER_BIND_PASSWORD = "server bind password";
+
+  private static String TEST_USER_BASE_DN = "User Base Dn";
+  private static String TEST_USER_REQUEST = "User Request";
+  private static String TEST_USER_EMAIL_ATTRIBUTE = "EmailID";
+  private static String TEST_USER_REAL_NAME_ATTR = "Real Name Attr";
+  private static String TEST_USER_LOGIN_ATTR = "Login Attr";
+  private static String TEST_USER_OBJECT_CLASS = "Object class";
+
+  private static String TEST_GROUP_BASE_DN = "Group BaseDn";
+  private static String TEST_GROUP_ID_ATTR = "Id";
+  private static String TEST_GROUP_MEMBER = "Member";
+  private static String TEST_GROUP_REQUEST = "Group Request";
+
+  @Test
+  public void defaults() {
+    Settings settings = new Settings();
+    LdapSettings ldapSettings = new LdapSettings(settings);
+    validateDefaultSettings(ldapSettings);
+  }
+
+  @Test
+  public void oneLdapServerCustomSettingsTest() {
+    Settings settings = new Settings();
+    setTestSettingsForOneLdapServer(settings, LdapSettings.LDAP_PROPERTY_PREFIX, "");
+    LdapSettings ldapSettings = new LdapSettings(settings);
+
+    assertThat(ldapSettings.getLdapServerKeys()).isEmpty();
+    validateCustomSettings(ldapSettings, LdapSettings.LDAP_PROPERTY_PREFIX, "");
+  }
+
+  @Test
+  public void MultiLdapServerCustomSettingsTest() {
+    Settings settings = new Settings().setProperty(LdapSettings.LDAP_SERVERS_PROPERTY, "server1,server2");
+    setTestSettingsForOneLdapServer(settings, "server1", "server1");
+    setTestSettingsForOneLdapServer(settings, "server2", "server2");
+    LdapSettings ldapSettings = new LdapSettings(settings);
+
+    assertThat(ldapSettings.getLdapServerKeys()).isEqualTo(new String[] {"server1", "server2"});
+    validateCustomSettings(ldapSettings, "server1", "server1");
+    validateCustomSettings(ldapSettings, "server2", "server2");
+  }
+
+  @Test
+  public void isAutoDiscoveryEnabledTest() {
+    Settings settings = new Settings()
+      .setProperty(LdapSettings.LDAP_PROPERTY_PREFIX + LdapSettings.LDAP_REALM_PROPERTY_SUFFIX, "realmA");
+    LdapSettings ldapSettingsWithAutDiscoveryEnabled = new LdapSettings(settings);
+    assertThat(ldapSettingsWithAutDiscoveryEnabled.isAutoDiscoveryEnabled()).isTrue();
+
+    settings = new Settings()
+      .setProperty(LdapSettings.LDAP_PROPERTY_PREFIX + LdapSettings.LDAP_REALM_PROPERTY_SUFFIX, "realmA")
+      .setProperty(LdapSettings.LDAP_PROPERTY_PREFIX + LdapSettings.LDAP_URL_PROPERTY_SUFFIX, "ldap.server.url");
+    LdapSettings ldapSettingsWithAutDiscoveryDisabled = new LdapSettings(settings);
+    assertThat(ldapSettingsWithAutDiscoveryDisabled.isAutoDiscoveryEnabled()).isFalse();
+
+    ldapSettingsWithAutDiscoveryDisabled = new LdapSettings(new Settings());
+    assertThat(ldapSettingsWithAutDiscoveryDisabled.isAutoDiscoveryEnabled()).isFalse();
+  }
+
+  @Test
+  public void hasKeyTest() {
+    Settings settings = new Settings()
+      .setProperty(LdapSettings.LDAP_PROPERTY_PREFIX + LdapSettings.LDAP_REALM_PROPERTY_SUFFIX, "realmA");
+    LdapSettings ldapSetting = new LdapSettings(settings);
+    assertThat(ldapSetting.hasKey(LdapSettings.LDAP_PROPERTY_PREFIX + LdapSettings.LDAP_REALM_PROPERTY_SUFFIX)).isTrue();
+    assertThat(ldapSetting.hasKey(LdapSettings.LDAP_PROPERTY_PREFIX + LdapSettings.LDAP_SERVERS_PROPERTY)).isFalse();
+  }
+
+  private void setTestSettingsForOneLdapServer(Settings settings, String settingsKeyPrefix, String settingsValuePrefix) {
+    settings.setProperty(settingsKeyPrefix + LdapSettings.AUTHENTICATION_METHOD_PROPERTY_SUFFIX, settingsValuePrefix + TEST_LDAP_AUTHENTICATION_METHOD);
+    settings.setProperty(settingsKeyPrefix + LdapSettings.CONTEXT_FACTORY_CLASS_PROPERTY_SUFFIX, settingsValuePrefix + TEST_LDAP_CONTEXT_FACTORY);
+    settings.setProperty(settingsKeyPrefix + LdapSettings.LDAP_URL_PROPERTY_SUFFIX, settingsValuePrefix + TEST_LDAP_URL);
+    settings.setProperty(settingsKeyPrefix + LdapSettings.LDAP_BIND_DN_PROPERTY_SUFFIX, settingsValuePrefix + TEST_SERVER_BIND_DN);
+    settings.setProperty(settingsKeyPrefix + LdapSettings.LDAP_BIND_PWD_PROPERTY_SUFFIX, settingsValuePrefix + TEST_SERVER_BIND_PASSWORD);
+
+    settings.setProperty(settingsKeyPrefix + LdapSettings.User.BASE_DN_PROPERTY_SUFFIX, settingsValuePrefix + TEST_USER_BASE_DN);
+    settings.setProperty(settingsKeyPrefix + LdapSettings.User.REQUEST_PROPERTY_SUFFIX, settingsValuePrefix + TEST_USER_REQUEST);
+    settings.setProperty(settingsKeyPrefix + LdapSettings.User.EMAIL_ATTRIBUTE_PROPERTY_SUFFIX, settingsValuePrefix + TEST_USER_EMAIL_ATTRIBUTE);
+    settings.setProperty(settingsKeyPrefix + LdapSettings.User.REAL_NAME_ATTRIBUTE_PROPERTY_SUFFIX, settingsValuePrefix + TEST_USER_REAL_NAME_ATTR);
+    settings.setProperty(settingsKeyPrefix + LdapSettings.User.LOGIN_ATTRIBUTE_PROPERTY_SUFFIX, settingsValuePrefix + TEST_USER_LOGIN_ATTR);
+    settings.setProperty(settingsKeyPrefix + LdapSettings.User.OBJECT_CLASS_PROPERTY_SUFFIX, settingsValuePrefix + TEST_USER_OBJECT_CLASS);
+
+    settings.setProperty(settingsKeyPrefix + LdapSettings.Group.BASE_DN_PROPERTY_SUFFIX, settingsValuePrefix + TEST_GROUP_BASE_DN);
+    settings.setProperty(settingsKeyPrefix + LdapSettings.Group.ID_ATTRIBUTE_PROPERTY_SUFFIX, settingsValuePrefix + TEST_GROUP_ID_ATTR);
+    settings.setProperty(settingsKeyPrefix + LdapSettings.Group.MEMBER_ATTRIBUTE_PROPERTY_SUFFIX, settingsValuePrefix + TEST_GROUP_MEMBER);
+    settings.setProperty(settingsKeyPrefix + LdapSettings.Group.REQUEST_PROPERTY_SUFFIX, settingsValuePrefix + TEST_GROUP_REQUEST);
+  }
+
+  private void validateCustomSettings(LdapSettings ldapSettings, String settingsPrefix, String testValuePrefix) {
+    assertThat(ldapSettings.getLdapAuthenticationOrDefault(settingsPrefix))
+      .isEqualTo(testValuePrefix + TEST_LDAP_AUTHENTICATION_METHOD);
+    assertThat(ldapSettings.getLdapContextFactoryOrDefault(settingsPrefix))
+      .isEqualTo(testValuePrefix + TEST_LDAP_CONTEXT_FACTORY);
+    assertThat(ldapSettings.getLdapUrl(settingsPrefix)).isEqualTo(testValuePrefix + TEST_LDAP_URL);
+    assertThat(ldapSettings.getBindUserNameDn(settingsPrefix)).isEqualTo(testValuePrefix + TEST_SERVER_BIND_DN);
+    assertThat(ldapSettings.getBindPassword(settingsPrefix)).isEqualTo(testValuePrefix + TEST_SERVER_BIND_PASSWORD);
+
+    assertThat(ldapSettings.getUserBaseDn(settingsPrefix)).isEqualTo(testValuePrefix + TEST_USER_BASE_DN);
+    assertThat(ldapSettings.getUserRequestOrDefault(settingsPrefix)).isEqualTo(testValuePrefix + TEST_USER_REQUEST);
+    assertThat(ldapSettings.getUserEmailAttributeOrDefault(settingsPrefix)).isEqualTo(testValuePrefix + TEST_USER_EMAIL_ATTRIBUTE);
+    assertThat(ldapSettings.getUserRealNameAttributeOrDefault(settingsPrefix)).isEqualTo(testValuePrefix + TEST_USER_REAL_NAME_ATTR);
+    assertThat(ldapSettings.getUserLoginAttributeOrDefault(settingsPrefix)).isEqualTo(testValuePrefix + TEST_USER_LOGIN_ATTR);
+    assertThat(ldapSettings.getUserObjectClassAttributeOrDefault(settingsPrefix)).isEqualTo(testValuePrefix + TEST_USER_OBJECT_CLASS);
+
+    assertThat(ldapSettings.getUserGroupBaseDn(settingsPrefix)).isEqualTo(testValuePrefix + TEST_GROUP_BASE_DN);
+    assertThat(ldapSettings.getUserGroupIdAttributeOrDefault(settingsPrefix)).isEqualTo(testValuePrefix + TEST_GROUP_ID_ATTR);
+    assertThat(ldapSettings.getUserGroupMemberAttributeOrDefault(settingsPrefix)).isEqualTo(testValuePrefix + TEST_GROUP_MEMBER);
+    assertThat(ldapSettings.getUserGroupRequestOrDefault(settingsPrefix)).isEqualTo(testValuePrefix + TEST_GROUP_REQUEST);
+  }
+
+  private void validateDefaultSettings(LdapSettings ldapSettings) {
+    assertThat(ldapSettings.getLdapContextFactoryOrDefault(LdapSettings.LDAP_PROPERTY_PREFIX))
+      .isEqualTo(LdapSettings.DEFAULT_LDAP_CONTEXT_FACTORY);
+    assertThat(ldapSettings.getLdapAuthenticationOrDefault(LdapSettings.LDAP_PROPERTY_PREFIX))
+      .isEqualTo(LdapSettings.DEFAULT_AUTHENTICATION);
+
+    assertThat(ldapSettings.getLdapServerKeys()).isEmpty();
+    assertThat(ldapSettings.getLdapRealm(LdapSettings.LDAP_PROPERTY_PREFIX)).isNull();
+    assertThat(ldapSettings.getLdapUrl(LdapSettings.LDAP_PROPERTY_PREFIX)).isNull();
+    assertThat(ldapSettings.getLdapUrlKey(LdapSettings.LDAP_PROPERTY_PREFIX)).isEqualTo("ldap.url");
+    assertThat(ldapSettings.getBindUserNameDn(LdapSettings.LDAP_PROPERTY_PREFIX)).isNull();
+    assertThat(ldapSettings.getBindPassword(LdapSettings.LDAP_PROPERTY_PREFIX)).isNull();
+
+    assertThat(ldapSettings.getUserBaseDn(LdapSettings.LDAP_PROPERTY_PREFIX)).isNull();
+    assertThat(ldapSettings.getUserRequestOrDefault(LdapSettings.LDAP_PROPERTY_PREFIX))
+      .isEqualTo(LdapSettings.User.DEFAULT_REQUEST);
+    assertThat(ldapSettings.getUserEmailAttributeOrDefault(LdapSettings.LDAP_PROPERTY_PREFIX))
+      .isEqualTo(LdapSettings.User.DEFAULT_EMAIL_ATTRIBUTE);
+    assertThat(ldapSettings.getUserRealNameAttributeOrDefault(LdapSettings.LDAP_PROPERTY_PREFIX))
+      .isEqualTo(LdapSettings.User.DEFAULT_REAL_NAME_ATTRIBUTE);
+    assertThat(ldapSettings.getUserLoginAttributeOrDefault(LdapSettings.LDAP_PROPERTY_PREFIX))
+      .isEqualTo(LdapSettings.User.DEFAULT_LOGIN_ATTRIBUTE);
+    assertThat(ldapSettings.getUserLoginAttribute(LdapSettings.LDAP_PROPERTY_PREFIX)).isNull();
+    assertThat(ldapSettings.getUserObjectClassAttributeOrDefault(LdapSettings.LDAP_PROPERTY_PREFIX))
+      .isEqualTo(LdapSettings.User.DEFAULT_OBJECT_CLASS);
+    assertThat(ldapSettings.getUserObjectClassAttribute(LdapSettings.LDAP_PROPERTY_PREFIX)).isNull();
+
+    assertThat(ldapSettings.getUserGroupBaseDn(LdapSettings.LDAP_PROPERTY_PREFIX)).isNull();
+    assertThat(ldapSettings.getUserGroupRequestOrDefault(LdapSettings.LDAP_PROPERTY_PREFIX))
+      .isEqualTo(LdapSettings.Group.DEFAULT_REQUEST);
+    assertThat(ldapSettings.getUserGroupIdAttributeOrDefault(LdapSettings.LDAP_PROPERTY_PREFIX))
+      .isEqualTo(LdapSettings.Group.DEFAULT_ID_ATTRIBUTE);
+    assertThat(ldapSettings.getUserGroupMemberAttributeOrDefault(LdapSettings.LDAP_PROPERTY_PREFIX))
+      .isEqualTo(LdapSettings.Group.DEFAULT_MEMBER_ATTRIBUTE);
+    assertThat(ldapSettings.getUserGroupMemberAttribute(LdapSettings.LDAP_PROPERTY_PREFIX)).isNull();
+    assertThat(ldapSettings.getUserGroupObjectClassOrDefault(LdapSettings.LDAP_PROPERTY_PREFIX))
+      .isEqualTo(LdapSettings.Group.DEFAULT_OBJECT_CLASS);
+    assertThat(ldapSettings.getUserGroupObjectClass(LdapSettings.LDAP_PROPERTY_PREFIX)).isNull();
+  }
+}

--- a/src/test/java/org/sonar/plugins/ldap/LdapUserMappingTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/LdapUserMappingTest.java
@@ -28,15 +28,15 @@ public class LdapUserMappingTest {
 
   @Test
   public void defaults() {
-    LdapUserMapping userMapping = new LdapUserMapping(new Settings(), "ldap");
+    LdapUserMapping userMapping = new LdapUserMapping(new LdapSettings(new Settings()), "ldap");
     assertThat(userMapping.getBaseDn()).isNull();
-    assertThat(userMapping.getRequest()).isEqualTo("(&(objectClass=inetOrgPerson)(uid={0}))");
+    assertThat(userMapping.getRequest()).isEqualTo("(|(&(objectClass=inetOrgPerson)(uid={0}))(&(objectClass=user)(sAMAccountName={0})))");
     assertThat(userMapping.getRealNameAttribute()).isEqualTo("cn");
     assertThat(userMapping.getEmailAttribute()).isEqualTo("mail");
 
     assertThat(userMapping.toString()).isEqualTo("LdapUserMapping{" +
       "baseDn=null," +
-      " request=(&(objectClass=inetOrgPerson)(uid={0}))," +
+      " request=(|(&(objectClass=inetOrgPerson)(uid={0}))(&(objectClass=user)(sAMAccountName={0})))," +
       " realNameAttribute=cn," +
       " emailAttribute=mail}");
   }
@@ -44,11 +44,11 @@ public class LdapUserMappingTest {
   @Test
   public void activeDirectory() {
     Settings settings = new Settings()
-        .setProperty("ldap.user.baseDn", "cn=users")
-        .setProperty("ldap.user.objectClass", "user")
-        .setProperty("ldap.user.loginAttribute", "sAMAccountName");
+      .setProperty("ldap.user.baseDn", "cn=users")
+      .setProperty("ldap.user.objectClass", "user")
+      .setProperty("ldap.user.loginAttribute", "sAMAccountName");
 
-    LdapUserMapping userMapping = new LdapUserMapping(settings, "ldap");
+    LdapUserMapping userMapping = new LdapUserMapping(new LdapSettings(settings), "ldap");
     LdapSearch search = userMapping.createSearch(null, "tester");
     assertThat(search.getBaseDn()).isEqualTo("cn=users");
     assertThat(search.getRequest()).isEqualTo("(&(objectClass=user)(sAMAccountName={0}))");
@@ -65,11 +65,11 @@ public class LdapUserMappingTest {
   @Test
   public void realm() {
     Settings settings = new Settings()
-        .setProperty("ldap.realm", "example.org")
-        .setProperty("ldap.userObjectClass", "user")
-        .setProperty("ldap.loginAttribute", "sAMAccountName");
+      .setProperty("ldap.realm", "example.org")
+      .setProperty("ldap.userObjectClass", "user")
+      .setProperty("ldap.loginAttribute", "sAMAccountName");
 
-    LdapUserMapping userMapping = new LdapUserMapping(settings, "ldap");
+    LdapUserMapping userMapping = new LdapUserMapping(new LdapSettings(settings), "ldap");
     assertThat(userMapping.getBaseDn()).isEqualTo("dc=example,dc=org");
   }
 

--- a/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelperTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelperTest.java
@@ -403,7 +403,7 @@ public class WindowsAuthenticationHelperTest {
   private static WindowsAuthenticationHelper getWindowsAuthHelperForGetUserDetailsTest(String domainName, String userName,
     boolean doesUserExist, UserDetails expectedUserDetails) {
     IWindowsAuthProvider windowsAuthProvider = mock(IWindowsAuthProvider.class);
-    WindowsAuthSettings windowsAuthSettings = new WindowsAuthSettings(new Settings());
+
     AdConnectionHelper adConnectionHelper = mock(AdConnectionHelper.class);
     String userNameWithDomain = getAccountNameWithDomain(domainName, "\\", userName);
     if (doesUserExist) {
@@ -416,13 +416,13 @@ public class WindowsAuthenticationHelperTest {
 
     Map<String, String> attributesUserDetails = null;
     if (expectedUserDetails != null) {
-      attributesUserDetails = new HashMap<>();
-      attributesUserDetails.put(windowsAuthSettings.getLdapUserRealNameAttribute(), expectedUserDetails.getName());
+      attributesUserDetails = new HashMap<String, String>();
+      attributesUserDetails.put(AdConnectionHelper.COMMON_NAME_ATTRIBUTE, expectedUserDetails.getName());
       attributesUserDetails.put(AdConnectionHelper.MAIL_ATTRIBUTE, expectedUserDetails.getEmail());
     }
 
-    Collection<String> attributeNames = new ArrayList<>();
-    attributeNames.add(windowsAuthSettings.getLdapUserRealNameAttribute());
+    Collection<String> attributeNames = new ArrayList<String>();
+    attributeNames.add(AdConnectionHelper.COMMON_NAME_ATTRIBUTE);
     attributeNames.add(AdConnectionHelper.MAIL_ATTRIBUTE);
     Mockito.when(adConnectionHelper.getUserDetails(domainName, userName, attributeNames)).thenReturn(attributesUserDetails);
 
@@ -439,12 +439,12 @@ public class WindowsAuthenticationHelperTest {
     Map<String, String> attributesUserDetails = null;
     if (expectedUserDetails != null) {
       attributesUserDetails = new HashMap<String, String>();
-      attributesUserDetails.put(windowsAuthSettings.getLdapUserRealNameAttribute(), expectedUserDetails.getName());
+      attributesUserDetails.put(AdConnectionHelper.COMMON_NAME_ATTRIBUTE, expectedUserDetails.getName());
       attributesUserDetails.put(AdConnectionHelper.MAIL_ATTRIBUTE, expectedUserDetails.getEmail());
     }
 
     Collection<String> attributeNames = new ArrayList<>();
-    attributeNames.add(windowsAuthSettings.getLdapUserRealNameAttribute());
+    attributeNames.add(AdConnectionHelper.COMMON_NAME_ATTRIBUTE);
     attributeNames.add(AdConnectionHelper.MAIL_ATTRIBUTE);
     Mockito.when(adConnectionHelper.getUserDetails(windowsAccount.getDomain(), windowsAccount.getName(), attributeNames)).thenReturn(attributesUserDetails);
 

--- a/src/test/java/org/sonar/plugins/ldap/windows/auth/WindowsAuthSettingsTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/windows/auth/WindowsAuthSettingsTest.java
@@ -35,8 +35,7 @@ public class WindowsAuthSettingsTest {
       .setProperty(WindowsAuthSettings.LDAP_WINDOWS_AUTH_SSO_PROTOCOLS, "")
       .setProperty(WindowsAuthSettings.LDAP_WINDOWS_AUTH, "")
       .setProperty(WindowsAuthSettings.LDAP_GROUP_ID_ATTRIBUTE, "")
-      .setProperty(WindowsAuthSettings.LDAP_WINDOWS_COMPATIBILITY_MODE, "")
-      .setProperty(WindowsAuthSettings.LDAP_WINDOWS_USER_REAL_NAME_ATTRIBUTE, "");
+      .setProperty(WindowsAuthSettings.LDAP_WINDOWS_COMPATIBILITY_MODE, "");
     WindowsAuthSettings windowsAuthSettingsWithBlankSettings = new WindowsAuthSettings(settingsWithBlankSettings);
 
     validateDefaultSettings(windowsAuthSettings);
@@ -45,13 +44,12 @@ public class WindowsAuthSettingsTest {
 
   @Test
   public void customSettings() {
-    final boolean sonarAuthenticatorDownCase = false;
-    final boolean sonarAuthenticatorGroupDownCase = false;
-    final boolean sonarLdapWindowsCompatibilityMode = true;
-    final String sonarLdapWindowsAuth = "true";
-    final String sonarLdapWindowsGroupIdAttribute = "userPrincipalName";
-    final String protocols = "someProtocol1 someProtocol2";
-    final String userRealNameAttribute = "someAttribute";
+    boolean sonarAuthenticatorDownCase = false;
+    boolean sonarAuthenticatorGroupDownCase = false;
+    boolean sonarLdapWindowsCompatibilityMode = true;
+    String sonarLdapWindowsAuth = "true";
+    String sonarLdapWindowsGroupIdAttribute = "userPrincipalName";
+    String protocols = "someProtocol1 someProtocol2";
 
     Settings settings = new Settings()
       .setProperty(WindowsAuthSettings.LDAP_WINDOWS_GROUP_DOWNCASE, Boolean.toString(sonarAuthenticatorGroupDownCase))
@@ -59,8 +57,7 @@ public class WindowsAuthSettingsTest {
       .setProperty(WindowsAuthSettings.LDAP_WINDOWS_AUTH, sonarLdapWindowsAuth)
       .setProperty(WindowsAuthSettings.LDAP_WINDOWS_COMPATIBILITY_MODE, Boolean.toString(sonarLdapWindowsCompatibilityMode))
       .setProperty(WindowsAuthSettings.LDAP_GROUP_ID_ATTRIBUTE, sonarLdapWindowsGroupIdAttribute)
-      .setProperty(WindowsAuthSettings.LDAP_WINDOWS_AUTH_SSO_PROTOCOLS, protocols)
-      .setProperty(WindowsAuthSettings.LDAP_WINDOWS_USER_REAL_NAME_ATTRIBUTE, userRealNameAttribute);
+      .setProperty(WindowsAuthSettings.LDAP_WINDOWS_AUTH_SSO_PROTOCOLS, protocols);
 
     WindowsAuthSettings windowsAuthSettings = new WindowsAuthSettings(settings);
 
@@ -70,7 +67,6 @@ public class WindowsAuthSettingsTest {
     assertThat(windowsAuthSettings.getIsLdapWindowsCompatibilityModeEnabled()).isEqualTo(sonarLdapWindowsCompatibilityMode);
     assertThat(windowsAuthSettings.getGroupIdAttribute()).isEqualTo(sonarLdapWindowsGroupIdAttribute);
     assertThat(windowsAuthSettings.getProtocols()).isEqualTo(protocols);
-    assertThat(windowsAuthSettings.getLdapUserRealNameAttribute()).isEqualTo(userRealNameAttribute);
   }
 
   private static void validateDefaultSettings(WindowsAuthSettings windowsAuthSettings) {
@@ -80,6 +76,5 @@ public class WindowsAuthSettingsTest {
     assertThat(windowsAuthSettings.getIsLdapWindowsCompatibilityModeEnabled()).isEqualTo(WindowsAuthSettings.DEFAULT_WINDOWS_COMPATIBILITY_MODE);
     assertThat(windowsAuthSettings.getGroupIdAttribute()).isEqualTo(WindowsAuthSettings.DEFAULT_LDAP_WINDOWS_GROUP_ID_ATTRIBUTE);
     assertThat(windowsAuthSettings.getProtocols()).isEqualTo(WindowsAuthSettings.DEFAULT_SONAR_WINDOWS_AUTH_SSO_PROTOCOLS);
-    assertThat(windowsAuthSettings.getLdapUserRealNameAttribute()).isEqualTo(WindowsAuthSettings.DEFAULT_USER_REAL_NAME_ATTRIBUTE);
   }
 }


### PR DESCRIPTION
Reducing the number of settings required in auto-discovery in non-windows authentication mode:

With this change we will need following settings in ldap's non-windows
auth mode  to run in auto discovery mode.
# LDAP configuration

sonar.security.realm=LDAP
ldap.windows.auth=false
ldap.bindDn=<your.bind.dn>
ldap.bindPassword=<your.bind.password>
ldap.realm=<your.domain.com>

Changes done:
- In context of Active Directory: Default user/group requests are
  updated to include default active directory requests as well.
- Auto-discovering user-Group's baseDn if auto-discovery mode is enabled

Refactoring :
- Moved all the ldap settings logic into separate class : LdapSettings.
  Unit Test is also added for LdapSettings
- Migrated the Ldap plugin to use
  - Authenticator in place of deprecated LoginPasswordAuthenticator class.
  - ExternalGroupsProvider.doGetGroups(String username) to
    ExternalGroupsProvider.doGetGroups(Context context)
  - ExternalUsersProvider.doGetUserDetails(@Nullable String username) to
    ExternalUsersProvider.doGetUserDetails(Context context)
- Fixed certain issues reported by SonarQube analysis on LDAP plugins code base.

Testing:
Non-Windows auth mode testing
- Testing done in auto-discovery mode
- Testing done in various configurations of ldap
   with/without groups syncing
  Windows auth mode testing
  Sanity testing for windows auth mode.
