### PR TITLE
Update waffle to 1.8.1 to allow negotiate with domain account.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <dependency>
       <groupId>com.github.dblock.waffle</groupId>
       <artifactId>waffle-jna</artifactId>
-      <version>1.8.0</version>
+      <version>1.8.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This update to waffle allows tomcat to run as a domain account while using Negotiate.

See: https://github.com/dblock/waffle/issues/268