### PR TITLE
Converting email from LDAP to lower case

### DIFF
--- a/sonar-ldap-plugin/src/main/java/org/sonar/plugins/ldap/LdapUsersProvider.java
+++ b/sonar-ldap-plugin/src/main/java/org/sonar/plugins/ldap/LdapUsersProvider.java
@@ -118,7 +118,7 @@ public class LdapUsersProvider extends ExternalUsersProvider {
     UserDetails details;
     details = new UserDetails();
     details.setName(getAttributeValue(attributes.get(userMappings.get(serverKey).getRealNameAttribute())));
-    details.setEmail(getAttributeValue(attributes.get(userMappings.get(serverKey).getEmailAttribute())));
+    details.setEmail(getAttributeValue(attributes.get(userMappings.get(serverKey).getEmailAttribute())).toLowerCase());
     return details;
   }
 


### PR DESCRIPTION
We have a problem with automatic issue assign using this plugin and emails containing upper case letters. The reason is that emails from SCM are automatically converted to lower case while emails from LDAP (AD) not and the users are not matched.

Converting to lower case allows case-insensitive matching (usually recommended for emails). If there is a reason why this conversion is not appropriate, a new boolean property can be created. Could you merge this so we can use the update center instead of custom builds? Thank you.
