### PR TITLE
ldap groups ending with fullstop

### DIFF
--- a/sonar-ldap-plugin/src/main/java/org/sonar/plugins/ldap/LdapAutodiscovery.java
+++ b/sonar-ldap-plugin/src/main/java/org/sonar/plugins/ldap/LdapAutodiscovery.java
@@ -112,10 +112,6 @@ public class LdapAutodiscovery {
       int weight = NumberUtils.toInt(srvData[1]);
       String port = srvData[2];
       String target = srvData[3];
-
-      if (target.endsWith(".")) {
-        target = target.substring(0, target.length() - 1);
-      }
       String server = "ldap://" + target + ":" + port;
       result.add(new LdapSrvRecord(server, priority, weight));
     }


### PR DESCRIPTION
Below code snippet broke our integration with AD groups, groups ending with "." exist.

if (target.endsWith(".")) {
        target = target.substring(0, target.length() - 1);
      }