### PR TITLE
Perform null check on LDAP bind account credentials

### DIFF
--- a/sonar-ldap-plugin/src/main/java/org/sonar/plugins/ldap/LdapContextFactory.java
+++ b/sonar-ldap-plugin/src/main/java/org/sonar/plugins/ldap/LdapContextFactory.java
@@ -127,8 +127,12 @@ public class LdapContextFactory {
       }
       // Explicitly initiate "bind" operation:
       ctx.addToEnvironment(Context.SECURITY_AUTHENTICATION, authentication);
-      ctx.addToEnvironment(Context.SECURITY_PRINCIPAL, principal);
-      ctx.addToEnvironment(Context.SECURITY_CREDENTIALS, credentials);
+      if (principal != null) {
+        ctx.addToEnvironment(Context.SECURITY_PRINCIPAL, principal);
+      }
+      if (credentials != null) {
+        ctx.addToEnvironment(Context.SECURITY_CREDENTIALS, credentials);
+      }
       ctx.reconnect(null);
     } else {
       ctx = new InitialLdapContext(getEnvironment(principal, credentials, pooling), null);


### PR DESCRIPTION
ldap.bindDn and ldap.bindPassword are not mandatory settings, but if
either of them is omitted from configuration but ldap.StartTLS is
enabled, Sonarqube will crash with NullPointerException when preparing
for LDAP Bind just after StartTLS is performed.

This commit adds the same null pointer checks that are enforced in
getEnvironment() when StartTLS is not used.