### PR TITLE
Manage membership in Sonar LDAP plugin

### DIFF
--- a/sonar-ldap-plugin/src/main/java/org/sonar/plugins/ldap/LdapGroupMapping.java
+++ b/sonar-ldap-plugin/src/main/java/org/sonar/plugins/ldap/LdapGroupMapping.java
@@ -42,6 +42,7 @@ public class LdapGroupMapping {
 
   private final String baseDn;
   private final String idAttribute;
+  private final String membershipAttribute;
   private final String request;
   private final String[] requiredUserAttributes;
 
@@ -51,6 +52,7 @@ public class LdapGroupMapping {
   public LdapGroupMapping(Settings settings, String settingsPrefix) {
     this.baseDn = settings.getString(settingsPrefix + ".group.baseDn");
     this.idAttribute = StringUtils.defaultString(settings.getString(settingsPrefix + ".group.idAttribute"), DEFAULT_ID_ATTRIBUTE);
+    this.membershipAttribute = StringUtils.defaultString(settings.getString(settingsPrefix + ".group.membershipAttribute"), null);
 
     String objectClass = settings.getString(settingsPrefix + ".group.objectClass");
     String memberAttribute = settings.getString(settingsPrefix + ".group.memberAttribute");
@@ -87,11 +89,11 @@ public class LdapGroupMapping {
         parameters[i] = getAttributeValue(user, attr);
       }
     }
-    return new LdapSearch(contextFactory)
-      .setBaseDn(getBaseDn())
-      .setRequest(getRequest())
-      .setParameters(parameters)
-      .returns(getIdAttribute());
+    LdapSearch ldapSearch= new LdapSearch(contextFactory)
+            .setBaseDn(getBaseDn())
+            .setRequest(getRequest())
+            .setParameters(parameters);
+          return (getMembershipAttribute() == null) ? ldapSearch.returns(getIdAttribute()) : ldapSearch.returns(getMembershipAttribute());
   }
 
   private static String getAttributeValue(SearchResult user, String attributeId) {
@@ -121,6 +123,13 @@ public class LdapGroupMapping {
   }
 
   /**
+   * MemberShip Attribute. Default is null.
+   */
+  public String getMembershipAttribute() {
+    return membershipAttribute;
+  }
+
+  /**
    * Request. For example:
    * <pre>
    * (&(objectClass=groupOfUniqueNames)(uniqueMember={0}))
@@ -144,6 +153,7 @@ public class LdapGroupMapping {
     return getClass().getSimpleName() + "{" +
       "baseDn=" + getBaseDn() +
       ", idAttribute=" + getIdAttribute() +
+      ", membershipAttribute=" + getMembershipAttribute() +
       ", requiredUserAttributes=" + Arrays.toString(getRequiredUserAttributes()) +
       ", request=" + getRequest() +
       "}";

--- a/sonar-ldap-plugin/src/test/java/org/sonar/plugins/ldap/LdapGroupMappingTest.java
+++ b/sonar-ldap-plugin/src/test/java/org/sonar/plugins/ldap/LdapGroupMappingTest.java
@@ -32,12 +32,14 @@ public class LdapGroupMappingTest {
 
     assertThat(groupMapping.getBaseDn()).isNull();
     assertThat(groupMapping.getIdAttribute()).isEqualTo("cn");
+    assertThat(groupMapping.getMembershipAttribute()).isEqualTo(null);
     assertThat(groupMapping.getRequest()).isEqualTo("(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))");
     assertThat(groupMapping.getRequiredUserAttributes()).isEqualTo(new String[] {"dn"});
 
     assertThat(groupMapping.toString()).isEqualTo("LdapGroupMapping{" +
       "baseDn=null," +
       " idAttribute=cn," +
+      " membershipAttribute=null," +
       " requiredUserAttributes=[dn]," +
       " request=(&(objectClass=groupOfUniqueNames)(uniqueMember={0}))}");
   }


### PR DESCRIPTION
In SonarQube, we need to give permissions to a single LDAP group which is a collection of other LDAP groups, so that users who are members of those groups can be authenticated.
But apparently it seems to be not possible to associate an authenticated user to that single group because there is no way to configure Sonar LDAP plugin for collecting all groups which user is member of as recursive searches are not allowed.
The property ldap.group.idAttribute returns a single attribute of the searched objects but we need to collect all attributes of a single searched object, so we introduced a new property: ldap.group.membershipAttribute that represents the attribute to be used for returning the list of user groups
With below configuration:
ldap.group.baseDn=cn=users,dc=acme,dc=it
ldap.group.request=(&(objectClass=inetOrgPerson)(uid={uid}))
ldap.group.membershipAttribute=memberOf

we will obtain the list of user groups which the authenticated user is member of.
